### PR TITLE
fix: update elastic search plugin to be compatible with latest search interface

### DIFF
--- a/search-elasticsearch/es.go
+++ b/search-elasticsearch/es.go
@@ -246,8 +246,10 @@ func (s *SearchEngine) buildQuery(cond *plugin.SearchBasicCond) (
 	log.Debugf("build query: %+v", cond)
 
 	q := elastic.NewBoolQuery()
-	if len(cond.TagIDs) > 0 {
-		q.Must(elastic.NewTermsQuery("tags", convertToInterfaceSlice(cond.TagIDs)...))
+	for _, tagGroup := range cond.TagIDs {
+		if len(tagGroup) > 0 {
+			q.Must(elastic.NewTermsQuery("tags", convertToInterfaceSlice(tagGroup)...))
+		}
 	}
 	if len(cond.UserID) > 0 {
 		q.Must(elastic.NewTermQuery("user_id", cond.UserID))


### PR DESCRIPTION
fix #49 . The current logic should be align with the tag search logic without using search plugin.