### PR TITLE
fix: update meilisearch and algolia search plugin to be compatible with latest search interface

### DIFF
--- a/search-algolia/algolia.go
+++ b/search-algolia/algolia.go
@@ -71,8 +71,14 @@ func (s *SearchAlgolia) SearchContents(ctx context.Context, cond *plugin.SearchB
 		votesFilter  string
 	)
 	if len(cond.TagIDs) > 0 {
-		for _, tagID := range cond.TagIDs {
-			tagFilters = append(tagFilters, "tags:"+tagID)
+		for _, tagGroup := range cond.TagIDs {
+			var tagsIn []string
+			if len(tagGroup) > 0 {
+				for _, tagID := range tagGroup {
+					tagsIn = append(tagsIn, "tags:" + tagID)
+				}
+			}
+			tagFilters = append(tagFilters, "(" + strings.Join(tagsIn, " OR ") + ")")
 		}
 		if len(tagFilters) > 0 {
 			filters += " AND " + strings.Join(tagFilters, " AND ")
@@ -121,8 +127,14 @@ func (s *SearchAlgolia) SearchQuestions(ctx context.Context, cond *plugin.Search
 		answersFilter string
 	)
 	if len(cond.TagIDs) > 0 {
-		for _, tagID := range cond.TagIDs {
-			tagFilters = append(tagFilters, "tags:"+tagID)
+		for _, tagGroup := range cond.TagIDs {
+			var tagsIn []string
+			if len(tagGroup) > 0 {
+				for _, tagID := range tagGroup {
+					tagsIn = append(tagsIn, "tags:" + tagID)
+				}
+			}
+			tagFilters = append(tagFilters, "(" + strings.Join(tagsIn, " OR ") + ")")
 		}
 		if len(tagFilters) > 0 {
 			filters += " AND " + strings.Join(tagFilters, " AND ")
@@ -178,8 +190,14 @@ func (s *SearchAlgolia) SearchAnswers(ctx context.Context, cond *plugin.SearchBa
 		questionIDFilter string
 	)
 	if len(cond.TagIDs) > 0 {
-		for _, tagID := range cond.TagIDs {
-			tagFilters = append(tagFilters, "tags:"+tagID)
+		for _, tagGroup := range cond.TagIDs {
+			var tagsIn []string
+			if len(tagGroup) > 0 {
+				for _, tagID := range tagGroup {
+					tagsIn = append(tagsIn, "tags:" + tagID)
+				}
+			}
+			tagFilters = append(tagFilters, "(" + strings.Join(tagsIn, " OR ") + ")")
 		}
 		if len(tagFilters) > 0 {
 			filters += " AND " + strings.Join(tagFilters, " AND ")

--- a/search-meilisearch/meilisearch.go
+++ b/search-meilisearch/meilisearch.go
@@ -23,13 +23,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/apache/incubator-answer-plugins/search-meilisearch/i18n"
 	"github.com/apache/incubator-answer/plugin"
 	"github.com/meilisearch/meilisearch-go"
 	"github.com/segmentfault/pacman/errors"
 	"github.com/segmentfault/pacman/log"
-	"strings"
-	"sync"
 )
 
 const (
@@ -321,7 +322,11 @@ func (s *Search) buildQuery(cond *plugin.SearchBasicCond) (string, *meilisearch.
 func (s *Search) buildFilter(cond *plugin.SearchBasicCond) []string {
 	var filter []string
 	if cond.TagIDs != nil && len(cond.TagIDs) > 0 {
-		filter = append(filter, fmt.Sprintf("tags IN [%s]", strings.Join(cond.TagIDs, ",")))
+		for _, tagGroup := range cond.TagIDs {
+			if len(tagGroup) > 0 {
+				filter = append(filter, fmt.Sprintf("tags IN [%s]", strings.Join(tagGroup, ",")))
+			}
+		}
 	}
 	if cond.UserID != "" {
 		filter = append(filter, fmt.Sprintf("userID = %s", cond.UserID))


### PR DESCRIPTION
fix #51 . The current logic is align with the tag search logic. both meili search and algolia search plugin have been tested.