### PR TITLE
修改企业微信中敏感信息邮箱节点为biz-email

### DIFF
--- a/user-center-wecom/schema.go
+++ b/user-center-wecom/schema.go
@@ -39,7 +39,7 @@ type AuthUserInfoResp struct {
 	Userid  string `json:"userid"`
 	Mobile  string `json:"mobile"`
 	Gender  string `json:"gender"`
-	Email   string `json:"email"`
+	Email   string `json:"biz_mail"`
 	Avatar  string `json:"avatar"`
 	QrCode  string `json:"qr_code"`
 	Address string `json:"address"`
@@ -49,7 +49,7 @@ type UserInfo struct {
 	Userid        string `json:"userid"`
 	Mobile        string `json:"mobile"`
 	Gender        string `json:"gender"`
-	Email         string `json:"email"`
+	Email         string `json:"biz_mail"`
 	Avatar        string `json:"avatar"`
 	QrCode        string `json:"qr_code"`
 	Address       string `json:"address"`


### PR DESCRIPTION
The email dictionary for sensitive information returned in wecom is changed from email to biz-email
![image](https://github.com/apache/incubator-answer-plugins/assets/5284443/eeaf4379-4d44-4a51-bd5d-5603c542b65e)

Here is the official response
![image](https://github.com/apache/incubator-answer-plugins/assets/5284443/37e3a78c-637e-4fb9-9ea3-f71222a07ee4)

For now, apps created in wecom with answer are new apps, according to the timeline
