### PR TITLE
fix(storage s3): public read acl

### DIFF
--- a/storage-s3/s3_client.go
+++ b/storage-s3/s3_client.go
@@ -55,6 +55,7 @@ func (s *Client) PutObject(key, ext string, file io.ReadSeeker) (err error) {
 	}
 	contentType := fmt.Sprintf("image/%s", strings.TrimPrefix(ext, "."))
 	_, err = s3.New(newSession).PutObject(&s3.PutObjectInput{
+		ACL:         aws.String("public-read"),
 		Body:        file,
 		Bucket:      aws.String(s.bucket),
 		Key:         aws.String(key),


### PR DESCRIPTION
When using digital ocean spaces files are private by default and require public-read acl.

Fixes #97 