### PR TITLE
Fix connector-google bug

### DIFF
--- a/connector-google/google.go
+++ b/connector-google/google.go
@@ -127,7 +127,7 @@ func (g *Connector) ConnectorReceiver(ctx *plugin.GinContext, receiverURL string
 	}
 
 	userInfo = plugin.ExternalLoginUserInfo{
-		ExternalID:  respGoogleAuthUserInfo.ID,
+		ExternalID:  respGoogleAuthUserInfo.Sub,
 		DisplayName: respGoogleAuthUserInfo.Name,
 		Username:    respGoogleAuthUserInfo.Name,
 		Email:       respGoogleAuthUserInfo.Email,


### PR DESCRIPTION
I tried connect to google but faced this issue:

![HTTP-Error-500-Apache-Answer](https://github.com/apache/incubator-answer-plugins/assets/88925843/ece4c352-5f74-443c-a89c-84892774b865)

Then I printed out fields in **userInfo** in function **ConnectorReceiver** in **google.go**. 

![image](https://github.com/apache/incubator-answer-plugins/assets/88925843/c786eef4-f165-447d-b575-84913ed4e0dc)

It turns out that google doesn't return **id** field as unique identifier for users, instead it uses **sub** field.

![image](https://github.com/apache/incubator-answer-plugins/assets/88925843/0954a25b-ae52-4721-82b3-9291f0a67031)

So I changed **ExternalID: respGoogleAuthUserInfo.ID**:
![before](https://github.com/apache/incubator-answer-plugins/assets/88925843/0ec2a218-3c75-4ace-82bb-cf95b1f0dc8a)

to **ExternalID: respGoogleAuthUserInfo.Sub**:
![after](https://github.com/apache/incubator-answer-plugins/assets/88925843/d6b338b0-2aba-465b-94ab-397d41406e10)

And I connected to google account successfully.