### PR TITLE
fix(util): runtime.Caller in go1.19 `skip` param error, `skip` in go1.19 is 0, in go1.21 is 1

### DIFF
--- a/util/go.mod
+++ b/util/go.mod
@@ -1,5 +1,5 @@
 module github.com/apache/incubator-answer-plugins/util
 
-go 1.21.4
+go 1.19
 
 require gopkg.in/yaml.v3 v3.0.1

--- a/util/util.go
+++ b/util/util.go
@@ -36,7 +36,7 @@ type Info struct {
 }
 
 func (c *Info) GetInfo() *Info {
-	_, filename, _, _ := runtime.Caller(0)
+	_, filename, _, _ := runtime.Caller(1)
 	wd := filepath.Dir(filename)
 
 	yamlFilePath := filepath.Join(wd, "info.yaml")


### PR DESCRIPTION
fix(util): runtime.Caller in go1.19 `skip` param error, `skip` in go1.19 is 0, in go1.21 is 1