### PR TITLE
fix `notification-dingtalk` and `storage-tencentyuncos`  module path error

### DIFF
--- a/notification-dingtalk/README.md
+++ b/notification-dingtalk/README.md
@@ -1,5 +1,14 @@
 # Ding talk Notification
 
+## How to use
+
+To use the notification-dingtalk plugin with your application, install it using the following command:
+
+```bash
+./answer build --with github.com/apache/incubator-answer-plugins/notification-dingtalk
+```
+
+
 ## Feature
 
 - Send message to Ding talk

--- a/notification-dingtalk/go.mod
+++ b/notification-dingtalk/go.mod
@@ -1,4 +1,4 @@
-module github.com/apache/incubator-answer-plugins/dingtalk
+module github.com/apache/incubator-answer-plugins/notification-dingtalk
 
 go 1.21.3
 

--- a/storage-tencentyuncos/go.mod
+++ b/storage-tencentyuncos/go.mod
@@ -1,4 +1,4 @@
-module github.com/apache/incubator-answer-plugins/tencentyuncos
+module github.com/apache/incubator-answer-plugins/storage-tencentyuncos
 
 go 1.21.3
 


### PR DESCRIPTION
The paths for the `notification-dingtalk` and `storage-tencentyuncos` plugins do not match the module definitions in the `go.mod` file. This inconsistency causes errors when running the `./answer build --with` command. 

This pull request makes the necessary adjustments to align the plugin paths with their corresponding module definitions in `go.mod` to resolve the build errors.