### PR TITLE
fix: restore Slack user center notification build

### DIFF
--- a/user-center-slack/notification.go
+++ b/user-center-slack/notification.go
@@ -24,6 +24,7 @@ import (
 
 	slackI18n "github.com/apache/answer-plugins/user-center-slack/i18n"
 	"github.com/apache/answer/plugin"
+	"github.com/go-resty/resty/v2"
 	"github.com/segmentfault/pacman/i18n"
 	"github.com/segmentfault/pacman/log"
 )


### PR DESCRIPTION
## Summary

- import the Resty v2 package used by the Slack user center notification sender
- restore compilation of the `user-center-slack` module

## Testing

- `go fmt ./...`
- `go test ./...`
- `go build ./...`
